### PR TITLE
feat: Support Godot 3

### DIFF
--- a/addons/godot-behavior-tree-plugin/failer.gd
+++ b/addons/godot-behavior-tree-plugin/failer.gd
@@ -11,7 +11,7 @@ func tick(tick):
 	for c in get_children():
 		var result = c._execute(tick)
 
-		if (typeof(result) == TYPE_OBJECT and result extends BehvError) or result == ERR_BUSY:
+		if (typeof(result) == TYPE_OBJECT and result is BehvError) or result == ERR_BUSY:
 			return result
 
 		return FAILED

--- a/addons/godot-behavior-tree-plugin/inverter.gd
+++ b/addons/godot-behavior-tree-plugin/inverter.gd
@@ -11,7 +11,7 @@ func tick(tick):
 	for c in get_children():
 		var result = c._execute(tick)
 
-		if (typeof(result) == TYPE_OBJECT and result extends BehvError) or result == ERR_BUSY:
+		if (typeof(result) == TYPE_OBJECT and result is BehvError) or result == ERR_BUSY:
 			return result
 		elif result == OK:
 			return FAILED

--- a/addons/godot-behavior-tree-plugin/repeat_until_fail.gd
+++ b/addons/godot-behavior-tree-plugin/repeat_until_fail.gd
@@ -13,7 +13,7 @@ func tick(tick):
 		while true:
 			var result = c._execute(tick)
 
-			if typeof(result) == TYPE_OBJECT and result extends BehvError:
+			if typeof(result) == TYPE_OBJECT and result is BehvError:
 				return result
 
 			if result == FAILED:

--- a/addons/godot-behavior-tree-plugin/repeat_until_succeed.gd
+++ b/addons/godot-behavior-tree-plugin/repeat_until_succeed.gd
@@ -13,7 +13,7 @@ func tick(tick):
 		while true:
 			var result = c._execute(tick)
 
-			if typeof(result) == TYPE_OBJECT and result extends BehvError:
+			if typeof(result) == TYPE_OBJECT and result is BehvError:
 				return result
 
 			if result == OK:

--- a/addons/godot-behavior-tree-plugin/repeater.gd
+++ b/addons/godot-behavior-tree-plugin/repeater.gd
@@ -13,7 +13,7 @@ func tick(tick):
 		while true:
 			var result = c.tick(tick)
 
-			if (typeof(result) == TYPE_OBJECT and result extends BehvError) or result == ERR_BUSY:
+			if (typeof(result) == TYPE_OBJECT and result is BehvError) or result == ERR_BUSY:
 				return result
 
 	return OK

--- a/addons/godot-behavior-tree-plugin/succeeder.gd
+++ b/addons/godot-behavior-tree-plugin/succeeder.gd
@@ -11,7 +11,7 @@ func tick(tick):
 	for c in get_children():
 		var result = c._execute(tick)
 
-		if (typeof(result) == TYPE_OBJECT and result extends BehvError) or result == ERR_BUSY:
+		if (typeof(result) == TYPE_OBJECT and result is BehvError) or result == ERR_BUSY:
 			return result
 
 		return OK


### PR DESCRIPTION
Godot 3 uses `is` instead of `extends` for testing inheritance.

fixes #7 