### PR TITLE
fix: memory leak

### DIFF
--- a/addons/godot-behavior-tree-plugin/tick.gd
+++ b/addons/godot-behavior-tree-plugin/tick.gd
@@ -1,5 +1,3 @@
-extends Node
-
 #Created by the tree and passed to nodes, this lets nodes know which tree they belong to, and gives them a reference to the blackboard being used for this tick.
 #It also holds the list of currently open nodes
 #Can be extended to do nodeCount and send debug info


### PR DESCRIPTION
`tick.gd` was a subclass of `Node`. In Godot, `Node` isn't reference
counted, so instances will stick around forever unless explicitly freed.
For Tick however, it doesn't actually need to extend from `Node`. Simply
extending from `Reference` (the default if no explicit parent class is
specified) is sufficient and `Reference` will be reference counted and
freed automatically.

fixes #6 