### PR TITLE
2 debug prints removed and solved several warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-.DS_Store
-.#*
-*~
+﻿*.import

--- a/addons/godot-behavior-tree-plugin/bt_base.gd
+++ b/addons/godot-behavior-tree-plugin/bt_base.gd
@@ -20,7 +20,6 @@ func _enter(tick):
 	enter(tick)
 
 func _open(tick):
-	print("opening node")
 	tick.openNode(self)
 	tick.blackboard.set('isOpen', true, tick.tree, self)
 	open(tick)
@@ -30,7 +29,6 @@ func _tick(tick):
 	return tick(tick)
 
 func _close(tick):
-	print("closing node")
 	tick.closeNode(self)
 	tick.blackboard.set('isOpen', false, tick.tree, self)
 	close(tick)

--- a/addons/godot-behavior-tree-plugin/bt_base.gd
+++ b/addons/godot-behavior-tree-plugin/bt_base.gd
@@ -38,17 +38,17 @@ func _exit(tick):
 	exit(tick)
 
 #the following functions are to be overridden in extending nodes
-func enter(tick):
+func enter(_tick):
 	pass
 
-func open(tick):
+func open(_tick):
 	pass
 
-func tick(tick):
+func tick(_tick):
 	return OK
 
-func close(tick):
+func close(_tick):
 	pass
 
-func exit(tick):
+func exit(_tick):
 	pass

--- a/addons/godot-behavior-tree-plugin/tick.gd
+++ b/addons/godot-behavior-tree-plugin/tick.gd
@@ -15,18 +15,18 @@ func _init():
 	actor = null
 	blackboard = []
 
-func openNode(node):
+func openNode(_node):
 	pass
 
 func enterNode(node):
 	openNodes.push_back(node)
 
-func tickNode(node):
+func tickNode(_node):
 	pass
 
 func closeNode(node):
 	if(openNodes.has(node)):
 		openNodes.remove(openNodes.find(node))
 
-func exitNode(node):
+func exitNode(_node):
 	pass


### PR DESCRIPTION
The debug prints may be useful for developing the plugin, but they were flooding the output console.
The other commit its just some parameter renaming to clear multiple warnings.
